### PR TITLE
Fix Gradio Button __init__ got an unexpected keyword argument 'label' in Gradio demo web UI

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -285,7 +285,7 @@ with gr.Blocks() as demo:
             text_prompt = gr.Textbox(label="Text Prompt")
             lama = gr.Button("Inpaint Image", variant="primary")
             replace_sd = gr.Button("Replace Anything with SD", variant="primary")
-            clear_button_image = gr.Button(value="Reset", label="Reset", variant="secondary") if hasattr(gr.Button, 'label') else clear_button_image = gr.Button(value="Reset", variant="secondary")                
+            clear_button_image = gr.Button(value="Reset", label="Reset", variant="secondary") if hasattr(gr.Button, 'label') else gr.Button(value="Reset", variant="secondary")                
 
     # todo: maybe we can delete this row, for it's unnecessary to show the original mask for customers
     with gr.Row(variant="panel"):

--- a/app/app.py
+++ b/app/app.py
@@ -285,7 +285,7 @@ with gr.Blocks() as demo:
             text_prompt = gr.Textbox(label="Text Prompt")
             lama = gr.Button("Inpaint Image", variant="primary")
             replace_sd = gr.Button("Replace Anything with SD", variant="primary")
-            clear_button_image = gr.Button(value="Reset", label="Reset", variant="secondary")
+            clear_button_image = gr.Button(value="Reset", label="Reset", variant="secondary") if hasattr(gr.Button, 'label') else clear_button_image = gr.Button(value="Reset", variant="secondary")                
 
     # todo: maybe we can delete this row, for it's unnecessary to show the original mask for customers
     with gr.Row(variant="panel"):


### PR DESCRIPTION
## Description

The Gradio demo web UI (`app.py`) passes an outdated or incorrect argument to the Gradio Button class (`label` ), causing a `TypeError` when the `Button` class does not accept this `label` attribute, leading to a failure of the web UI.

This pull request addresses an issue in the Gradio demo web UI (`app.py`), where an outdated or incorrect argument (`label`) get passed to the Gradio `Button` class, which causes a `TypeError` when the `Button` class did not accept it, leading to a failure in the web UI. This pull request updates the code to use the `label` argument based on its availability as a Button attribute.



### Changes Made

- Adjusted the Gradio `Button` instantiation in `app.py` to resolve the issue.

### Context

The original code might have been written for an older version of Gradio, where `label` was a valid argument. However, the current version does not support this argument, and the code needed adjustment.

### Checklist

- [x] I have tested the changes locally.
- [x] My code follows the coding conventions of the Inpaint-Anything project.