### PR TITLE
Fix for fake_fakes.py "cannot import name 'SamplePadding' from 'kornia'"

### DIFF
--- a/lama/saicinpainting/training/modules/fake_fakes.py
+++ b/lama/saicinpainting/training/modules/fake_fakes.py
@@ -1,5 +1,5 @@
 import torch
-from kornia import SamplePadding
+from kornia.constants import SamplePadding
 from kornia.augmentation import RandomAffine, CenterCrop
 
 


### PR DESCRIPTION
fix for "cannot import name 'SamplePadding' from 'kornia'"